### PR TITLE
Modify rebar.config for windows support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,12 @@
+%% vim: ts=2 sw=2 et ft=erlang
 {deps,
  [
   {proper, ".*", {git, "https://github.com/manopapad/proper.git", {branch, "master"}}},
   {proper_stdlib, ".*", {git, "https://github.com/spawngrid/proper_stdlib.git", {branch, "master"}}}
 ]}.
 {lib_dirs, ["deps"]}.
-{post_hooks, [{compile, "./post_compile.escript"}]}.
+{post_hooks,
+ [
+	{"(linux|bsd|darwin|solaris)", compile, "./post_compile.escript"},
+	{"win", compile, "escript.exe post_compile.escript"}
+]}.


### PR DESCRIPTION
So I just ran into a problem with compiling mimetypes on Windows.  The call to `./post_compile.escript` doesn't work on windows, as windows doesn't understand that line.

So for posix environments, we have no need to change the call, but on windows, we need to call `escript.exe` directly (even `escript` alone doesn't work).

I also added a vimline to the top to set tabstops, shiftwidth, and filetypes. If I'm overstepping my bounds there, please let me know, and I'll modify this request to remove it.

Please let me know if anything needs to change, or if you need anything else from me.

Thanks,

-Jesse
